### PR TITLE
feat!: On track with v1 on-ledger release

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -212,7 +212,7 @@ didCheqdMainnetProvider:
   $require: '@cheqd/did-provider-cheqd#CheqdDIDProvider'
   $args:
     - defaultKms: local
-      cosmosPayerMnemonic: 'your cosmos payer mnemonic'
+      cosmosPayerMnemonic: 'your cosmos payer mnemonic or private key in hex format'
       networkType: mainnet
       rpcUrl: 'https://rpc.cheqd.net'
 
@@ -220,7 +220,7 @@ didCheqdTestnetProvider:
   $require: '@cheqd/did-provider-cheqd#CheqdDIDProvider'
   $args:
     - defaultKms: local
-      cosmosPayerMnemonic: 'your cosmos payer mnemonic'
+      cosmosPayerMnemonic: 'your cosmos payer mnemonic or private key in hex format'
       networkType: testnet
       rpcUrl: 'https://rpc.cheqd.network'
 
@@ -286,5 +286,6 @@ agent:
             - $ref: /dbConnection
         - $require: '@cheqd/did-provider-cheqd#Cheqd'
           $args:
-            - provider:
-                $ref: /didCheqdTestnetProvider
+            - providers:
+                - $ref: /didCheqdTestnetProvider
+                - $ref: /didCheqdMainnetProvider

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cheqd/sdk": "^2.0.0-develop.1",
-        "@cheqd/ts-proto": "^1.0.16-develop.2",
+        "@cheqd/ts-proto": "^2.0.0-develop.1",
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/proto-signing": "^0.29.4",
         "@cosmjs/utils": "^0.29.4",
@@ -2365,19 +2365,10 @@
         "uuid": "^9.0.0"
       }
     },
-    "node_modules/@cheqd/sdk/node_modules/@cheqd/ts-proto": {
+    "node_modules/@cheqd/ts-proto": {
       "version": "2.0.0-develop.1",
       "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
       "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
-      "dependencies": {
-        "long": "^5.2.1",
-        "protobufjs": "~7.1.1"
-      }
-    },
-    "node_modules/@cheqd/ts-proto": {
-      "version": "1.0.16-develop.2",
-      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.2.tgz",
-      "integrity": "sha512-bx44Fe0Q/tfrGGfkt46Lx0Pjoo9gM1mfgAB54bPt1MEqM6lsgczP+SYINEwOIW8clwd6P6Ks6SVKetU2piIAuw==",
       "dependencies": {
         "long": "^5.2.1",
         "protobufjs": "~7.1.1"
@@ -28978,23 +28969,12 @@
         "did-resolver": "^4.0.1",
         "multiformats": "^9.9.0",
         "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "@cheqd/ts-proto": {
-          "version": "2.0.0-develop.1",
-          "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
-          "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
-          "requires": {
-            "long": "^5.2.1",
-            "protobufjs": "~7.1.1"
-          }
-        }
       }
     },
     "@cheqd/ts-proto": {
-      "version": "1.0.16-develop.2",
-      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-1.0.16-develop.2.tgz",
-      "integrity": "sha512-bx44Fe0Q/tfrGGfkt46Lx0Pjoo9gM1mfgAB54bPt1MEqM6lsgczP+SYINEwOIW8clwd6P6Ks6SVKetU2piIAuw==",
+      "version": "2.0.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
+      "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
       "requires": {
         "long": "^5.2.1",
         "protobufjs": "~7.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@cheqd/did-provider-cheqd",
-  "version": "1.7.20",
+  "version": "1.8.0-develop.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cheqd/did-provider-cheqd",
-      "version": "1.7.20",
+      "version": "1.8.0-develop.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cheqd/sdk": "^1.5.0-develop.1",
+        "@cheqd/sdk": "^2.0.0-develop.1",
         "@cheqd/ts-proto": "^1.0.16-develop.2",
+        "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/proto-signing": "^0.29.4",
         "@cosmjs/utils": "^0.29.4",
         "@veramo/core": "^4.1.1",
@@ -18,6 +19,7 @@
         "@veramo/did-provider-key": "^4.1.1",
         "@veramo/key-manager": "^4.1.1",
         "debug": "^4.3.4",
+        "did-resolver": "^4.0.1",
         "multibase": "^4.0.6",
         "multicodec": "^3.2.1",
         "uint8arrays": "^3.1.1"
@@ -2343,11 +2345,11 @@
       }
     },
     "node_modules/@cheqd/sdk": {
-      "version": "1.5.0-develop.1",
-      "resolved": "https://registry.npmjs.org/@cheqd/sdk/-/sdk-1.5.0-develop.1.tgz",
-      "integrity": "sha512-zrj9oQkUSfZ6u8Hsl2+vpwgm6w6R3wOnHUOoKe/6TwwHMp9mYp9zifmAe/n7WJH9JcOzhCKWlnMo8iXrnKuMrQ==",
+      "version": "2.0.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@cheqd/sdk/-/sdk-2.0.0-develop.1.tgz",
+      "integrity": "sha512-cDuiSKzwJEODjcGgyiWJNvZoS0fwKIQrBOQ9EJgFF/VP96VcfOYozxvma9QO5XAzh+8+G0aSKoi6nXAv3jFbOw==",
       "dependencies": {
-        "@cheqd/ts-proto": "^1.0.16-develop.2",
+        "@cheqd/ts-proto": "^2.0.0-develop.1",
         "@cosmjs/amino": "^0.29.4",
         "@cosmjs/encoding": "^0.29.4",
         "@cosmjs/math": "^0.29.4",
@@ -2358,8 +2360,18 @@
         "@stablelib/ed25519": "^1.0.3",
         "cosmjs-types": "^0.5.2",
         "did-jwt": "^6.9.0",
+        "did-resolver": "^4.0.1",
         "multiformats": "^9.9.0",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@cheqd/sdk/node_modules/@cheqd/ts-proto": {
+      "version": "2.0.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
+      "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
+      "dependencies": {
+        "long": "^5.2.1",
+        "protobufjs": "~7.1.1"
       }
     },
     "node_modules/@cheqd/ts-proto": {
@@ -2437,13 +2449,13 @@
       }
     },
     "node_modules/@cosmjs/crypto": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.4.tgz",
-      "integrity": "sha512-PmSxoFl/Won7kHZv3PQUUgdmEiAMqdY7XnEnVh9PbU7Hht6uo7PQ+M0eIGW3NIXYKmn6oVExER+xOfLfq4YNGw==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
+      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
       "dependencies": {
-        "@cosmjs/encoding": "^0.29.4",
-        "@cosmjs/math": "^0.29.4",
-        "@cosmjs/utils": "^0.29.4",
+        "@cosmjs/encoding": "^0.29.5",
+        "@cosmjs/math": "^0.29.5",
+        "@cosmjs/utils": "^0.29.5",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
@@ -2451,9 +2463,9 @@
       }
     },
     "node_modules/@cosmjs/encoding": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.4.tgz",
-      "integrity": "sha512-nlwCh4j+kIqEcwNu8AFSmqXGj0bvF4nLC3J1X0eJyJenlgJBiiAGjYp3nxMf/ZjKkZP65Fq7MXVtAYs3K8xvvQ==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
+      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -2470,9 +2482,9 @@
       }
     },
     "node_modules/@cosmjs/math": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.4.tgz",
-      "integrity": "sha512-IvT1Cj3qOMGqz7v5FxdDCBEIDL2k9m5rufrkuD4oL9kS79ebnhA0lquX6ApPubUohTXl+5PnLo02W8HEH6Stkg==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
+      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -2587,9 +2599,9 @@
       }
     },
     "node_modules/@cosmjs/utils": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.4.tgz",
-      "integrity": "sha512-X1pZWRHDbTPLa6cYW0NHvtig+lSxOdLAX7K/xp67ywBy2knnDOyzz1utGTOowmiM98XuV9quK/BWePKkJOaHpQ=="
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
+      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
     "node_modules/@did-core/data-model": {
       "version": "0.1.1-unstable.15",
@@ -28948,11 +28960,11 @@
       "integrity": "sha512-R524tD5VwOt3QRHr7N518nqTVR/HKgfWL4LypekcGuNQN8R4PWScvuRcRzrY39A28kLztMv+TJdiKuMNbkU1ug=="
     },
     "@cheqd/sdk": {
-      "version": "1.5.0-develop.1",
-      "resolved": "https://registry.npmjs.org/@cheqd/sdk/-/sdk-1.5.0-develop.1.tgz",
-      "integrity": "sha512-zrj9oQkUSfZ6u8Hsl2+vpwgm6w6R3wOnHUOoKe/6TwwHMp9mYp9zifmAe/n7WJH9JcOzhCKWlnMo8iXrnKuMrQ==",
+      "version": "2.0.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@cheqd/sdk/-/sdk-2.0.0-develop.1.tgz",
+      "integrity": "sha512-cDuiSKzwJEODjcGgyiWJNvZoS0fwKIQrBOQ9EJgFF/VP96VcfOYozxvma9QO5XAzh+8+G0aSKoi6nXAv3jFbOw==",
       "requires": {
-        "@cheqd/ts-proto": "^1.0.16-develop.2",
+        "@cheqd/ts-proto": "^2.0.0-develop.1",
         "@cosmjs/amino": "^0.29.4",
         "@cosmjs/encoding": "^0.29.4",
         "@cosmjs/math": "^0.29.4",
@@ -28963,8 +28975,20 @@
         "@stablelib/ed25519": "^1.0.3",
         "cosmjs-types": "^0.5.2",
         "did-jwt": "^6.9.0",
+        "did-resolver": "^4.0.1",
         "multiformats": "^9.9.0",
         "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "@cheqd/ts-proto": {
+          "version": "2.0.0-develop.1",
+          "resolved": "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-2.0.0-develop.1.tgz",
+          "integrity": "sha512-+dsHyZABC1spbkTjO1dGJOF20sHUumnDIoKGZtrWiu15iIa9vg2IAgKKVyLc7aBs04dxVs/888KN03zAWJvyJQ==",
+          "requires": {
+            "long": "^5.2.1",
+            "protobufjs": "~7.1.1"
+          }
+        }
       }
     },
     "@cheqd/ts-proto": {
@@ -29036,13 +29060,13 @@
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.4.tgz",
-      "integrity": "sha512-PmSxoFl/Won7kHZv3PQUUgdmEiAMqdY7XnEnVh9PbU7Hht6uo7PQ+M0eIGW3NIXYKmn6oVExER+xOfLfq4YNGw==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
+      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
       "requires": {
-        "@cosmjs/encoding": "^0.29.4",
-        "@cosmjs/math": "^0.29.4",
-        "@cosmjs/utils": "^0.29.4",
+        "@cosmjs/encoding": "^0.29.5",
+        "@cosmjs/math": "^0.29.5",
+        "@cosmjs/utils": "^0.29.5",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
@@ -29050,9 +29074,9 @@
       }
     },
     "@cosmjs/encoding": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.4.tgz",
-      "integrity": "sha512-nlwCh4j+kIqEcwNu8AFSmqXGj0bvF4nLC3J1X0eJyJenlgJBiiAGjYp3nxMf/ZjKkZP65Fq7MXVtAYs3K8xvvQ==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
+      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
       "requires": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -29069,9 +29093,9 @@
       }
     },
     "@cosmjs/math": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.4.tgz",
-      "integrity": "sha512-IvT1Cj3qOMGqz7v5FxdDCBEIDL2k9m5rufrkuD4oL9kS79ebnhA0lquX6ApPubUohTXl+5PnLo02W8HEH6Stkg==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
+      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
       "requires": {
         "bn.js": "^5.2.0"
       }
@@ -29185,9 +29209,9 @@
       }
     },
     "@cosmjs/utils": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.4.tgz",
-      "integrity": "sha512-X1pZWRHDbTPLa6cYW0NHvtig+lSxOdLAX7K/xp67ywBy2knnDOyzz1utGTOowmiM98XuV9quK/BWePKkJOaHpQ=="
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
+      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
     "@did-core/data-model": {
       "version": "0.1.1-unstable.15",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@cheqd/sdk": "^2.0.0-develop.1",
-    "@cheqd/ts-proto": "^1.0.16-develop.2",
+    "@cheqd/ts-proto": "^2.0.0-develop.1",
     "@cosmjs/crypto": "^0.29.5",
     "@cosmjs/proto-signing": "^0.29.4",
     "@cosmjs/utils": "^0.29.4",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
     ]
   },
   "dependencies": {
-    "@cheqd/sdk": "^1.5.0-develop.1",
+    "@cheqd/sdk": "^2.0.0-develop.1",
     "@cheqd/ts-proto": "^1.0.16-develop.2",
+    "@cosmjs/crypto": "^0.29.5",
     "@cosmjs/proto-signing": "^0.29.4",
     "@cosmjs/utils": "^0.29.4",
     "@veramo/core": "^4.1.1",
@@ -54,6 +55,7 @@
     "@veramo/did-provider-key": "^4.1.1",
     "@veramo/key-manager": "^4.1.1",
     "debug": "^4.3.4",
+    "did-resolver": "^4.0.1",
     "multibase": "^4.0.6",
     "multicodec": "^3.2.1",
     "uint8arrays": "^3.1.1"


### PR DESCRIPTION
- Bumps `@cheqd/sdk`, `@cheqd/did-provider-cheqd` to latest beta.
- Aligns Protobuf API to v2.
- Adds ability to pass private key as seed.
- Fixes auto-loading provider, mainnet or testnet by did doc id namespace.
- Adds safe handling of instantiating either provider, mainnet or testnet or both as standalones.