### PR TITLE
fix: Suspension & Unsuspension if already in required state

### DIFF
--- a/src/agent/ICheqd.ts
+++ b/src/agent/ICheqd.ts
@@ -1988,7 +1988,7 @@ export class Cheqd implements IAgentPlugin {
             const statusList = await StatusList.decode({ encodedList: statusList2021 })
 
             // early exit, if already suspended
-            if (statusList.getStatus(Number(credential.credentialStatus.statusListIndex))) return { suspended: false } satisfies SuspensionResult
+            if (statusList.getStatus(Number(credential.credentialStatus.statusListIndex))) return { suspended: true } satisfies SuspensionResult
 
             // update suspension status
             statusList.setStatus(Number(credential.credentialStatus.statusListIndex), true)
@@ -2112,11 +2112,11 @@ export class Cheqd implements IAgentPlugin {
             // parse status list 2021
             const statusList = await StatusList.decode({ encodedList: statusList2021 })
 
-            // early exit, if already suspended
-            if (statusList.getStatus(Number(credential.credentialStatus.statusListIndex))) return { unsuspended: false } satisfies UnsuspensionResult
+            // early exit, if already unsuspended
+            if (!statusList.getStatus(Number(credential.credentialStatus.statusListIndex))) return { unsuspended: true } satisfies UnsuspensionResult
 
             // update suspension status
-            statusList.setStatus(Number(credential.credentialStatus.statusListIndex), true)
+            statusList.setStatus(Number(credential.credentialStatus.statusListIndex), false)
 
             // set in-memory status list ref
             const bitstring = await statusList.encode() as Bitstring


### PR DESCRIPTION
Issue:
1. Suspend credential -> checks if already suspended -> return false
2. Unsuspend credential -> checks if already **suspended** -> return false if suspended
3. Unsuspend credential -> sets status to true

Fix:
1. Suspend credential -> checks if already suspended -> reutrn true
2. Unsuspend credential -> checks if already **unsuspended** -> return true if already unsuspended
3. Unsuspend credential -> sets status to false